### PR TITLE
got global stats out from under header

### DIFF
--- a/src/components/GlobalStats.js
+++ b/src/components/GlobalStats.js
@@ -5,7 +5,7 @@ class GlobalStats extends Component {
 
     render() {
         return(
-            <div>
+            <div style={{marginTop:'80px'}}>
             <h4 style={{paddingLeft:"27px"}}>Global Stats: {this.props.global.TotalConfirmed} cases; {this.props.global.TotalDeaths} deaths; {this.props.global.TotalRecovered} recovered</h4>
             </div>
         )


### PR DESCRIPTION
They slid up under the header when I made it a fixed element. :0